### PR TITLE
Add OVS install-files options for configure

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -88,7 +88,7 @@ sudo ${DPDK_DIR}/usertools/dpdk-devbind.py --status
 export OVS_DIR=/usr/src/openvswitch-2.9.2
 cd $OVS_DIR
 ./boot.sh
-CFLAGS='-march=native' ./configure --with-dpdk=$DPDK_BUILD
+CFLAGS='-march=native' ./configure --prefix=/usr --localstatedir=/var --sysconfdir=/etc --with-dpdk=$DPDK_BUILD
 make && sudo make install
 sudo mkdir -p /usr/local/etc/openvswitch
 sudo mkdir -p /usr/local/var/run/openvswitch


### PR DESCRIPTION
Default all files are installed under /usr/local. Let's install all
files into, e.g., /usr and /var instead of /usr/local and /usr/local/var
and expect to use /etc/openvswitch as the default database directory.
Ref:
http://docs.openvswitch.org/en/latest/intro/install/general/#installation-requirements